### PR TITLE
Added PlayerDeathBanEvent

### DIFF
--- a/src/main/java/sh/okx/deathban/DeathBan.java
+++ b/src/main/java/sh/okx/deathban/DeathBan.java
@@ -95,12 +95,7 @@ public class DeathBan extends JavaPlugin {
   public boolean checkBan(PlayerData data) {
     Player player = Bukkit.getPlayer(data.getUuid());
     Group group = getGroup(player);
-    if (data.getDeaths() < group.getLives()) {
-      return false;
-    }
-
-    Bukkit.getScheduler().runTask(this, () -> ban(player, group.getTime(data.getBans())));
-    return true;
+    return data.getDeaths() >= group.getLives();
   }
 
   public void ban(Player player, long time) {

--- a/src/main/java/sh/okx/deathban/commands/ReviveCommand.java
+++ b/src/main/java/sh/okx/deathban/commands/ReviveCommand.java
@@ -61,7 +61,9 @@ public class ReviveCommand implements CommandExecutor {
       send(player, plugin.getMessage("revive.transferred"), revive);
     }
 
-    plugin.checkBan(data);
+    if(plugin.checkBan(data)){
+      plugin.ban(player, plugin.getGroup(player).getTime());
+    }
     plugin.getSDatabase().save(reviveData);
     return true;
   }

--- a/src/main/java/sh/okx/deathban/events/PlayerDeathBanEvent.java
+++ b/src/main/java/sh/okx/deathban/events/PlayerDeathBanEvent.java
@@ -1,0 +1,47 @@
+package sh.okx.deathban.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import sh.okx.deathban.database.PlayerData;
+
+public class PlayerDeathBanEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Player player;
+    private final PlayerData data;
+    private boolean cancelled;
+
+
+    public PlayerDeathBanEvent(Player player, PlayerData data, boolean cancelled){
+        this.player = player;
+        this.data = data;
+        this.cancelled = cancelled;
+    }
+
+
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public PlayerData getData() {
+        return data;
+    }
+}

--- a/src/main/java/sh/okx/deathban/events/PlayerDeathBanEvent.java
+++ b/src/main/java/sh/okx/deathban/events/PlayerDeathBanEvent.java
@@ -2,28 +2,37 @@ package sh.okx.deathban.events;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
-import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 import sh.okx.deathban.database.PlayerData;
 
-public class PlayerDeathBanEvent extends Event implements Cancellable {
+public class PlayerDeathBanEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList HANDLERS = new HandlerList();
-    private final Player player;
     private final PlayerData data;
     private boolean cancelled;
 
-
+    /**
+     * Event fired when a player dies and should be banned.
+     * To prevent the player involved in this event from getting banned, this event must be cancelled.
+     * @param player The player involved in this event.
+     * @param data The PlayerData before the player was banned.
+     * @param cancelled Whether the event should be cancelled or not.
+     */
     public PlayerDeathBanEvent(Player player, PlayerData data, boolean cancelled){
+        super(player);
         this.player = player;
         this.data = data;
         this.cancelled = cancelled;
     }
 
 
-
     @Override
     public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
         return HANDLERS;
     }
 
@@ -35,10 +44,6 @@ public class PlayerDeathBanEvent extends Event implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
-    }
-
-    public Player getPlayer() {
-        return player;
     }
 
     public PlayerData getData() {

--- a/src/main/java/sh/okx/deathban/listeners/DeathListener.java
+++ b/src/main/java/sh/okx/deathban/listeners/DeathListener.java
@@ -19,7 +19,10 @@ public class DeathListener implements Listener {
     Player player = e.getEntity();
     PlayerData data = plugin.getSDatabase().getData(player.getUniqueId());
     data.setDeaths(data.getDeaths() + 1);
-    if(!plugin.checkBan(data)) return;
+    if(!plugin.checkBan(data)) {
+      plugin.getSDatabase().save(data);
+      return;
+    }
 
     PlayerDeathBanEvent event = new PlayerDeathBanEvent(player,
             data,
@@ -31,6 +34,7 @@ public class DeathListener implements Listener {
     //Revert death addition if event was cancelled
     if(event.isCancelled()){
       data.setDeaths(data.getDeaths() - 1);
+      plugin.getSDatabase().save(data);
       return;
     }
 

--- a/src/main/java/sh/okx/deathban/listeners/DeathListener.java
+++ b/src/main/java/sh/okx/deathban/listeners/DeathListener.java
@@ -1,12 +1,14 @@
 package sh.okx.deathban.listeners;
 
 import lombok.RequiredArgsConstructor;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import sh.okx.deathban.DeathBan;
 import sh.okx.deathban.database.PlayerData;
+import sh.okx.deathban.events.PlayerDeathBanEvent;
 
 @RequiredArgsConstructor
 public class DeathListener implements Listener {
@@ -15,13 +17,25 @@ public class DeathListener implements Listener {
   @EventHandler
   public void on(PlayerDeathEvent e) {
     Player player = e.getEntity();
-    if (player.hasPermission("deathban.bypass")) {
+    PlayerData data = plugin.getSDatabase().getData(player.getUniqueId());
+    data.setDeaths(data.getDeaths() + 1);
+    if(!plugin.checkBan(data)) return;
+
+    PlayerDeathBanEvent event = new PlayerDeathBanEvent(player,
+            data,
+            player.hasPermission("deathban.bypass"));
+
+    //Fire event
+    Bukkit.getPluginManager().callEvent(event);
+
+    //Revert death addition if event was cancelled
+    if(event.isCancelled()){
+      data.setDeaths(data.getDeaths() - 1);
       return;
     }
 
-    PlayerData data = plugin.getSDatabase().getData(player.getUniqueId());
-    data.setDeaths(data.getDeaths() + 1);
-    plugin.checkBan(data);
+    //Finally ban the player
+    plugin.ban(player, plugin.getGroup(player).getTime());
     plugin.getSDatabase().save(data);
   }
 }


### PR DESCRIPTION
Added PlayerDeathBanEvent (event fired when a player is about to get banned), which can be cancelled. Changed DeathBan#checkBan so now it does not ban automatically if the player should be banned, instead, if said method returns true, DeathBan#ban must be called afterwards in order to ban the player.